### PR TITLE
relax FHIRModels version requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.0.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/FHIRModels.git", from: "0.5.0"),
+        .package(url: "https://github.com/apple/FHIRModels.git", from: "0.7.0"),
         .package(url: "https://github.com/StanfordBDHG/ResearchKit.git", from: "3.0.1"),
         .package(url: "https://github.com/StanfordBDHG/ResearchKitOnFHIR.git", from: "2.0.1")
     ] + swiftLintPackage(),

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/FHIRModels.git", from: "0.7.0"),
         .package(url: "https://github.com/StanfordBDHG/ResearchKit.git", from: "3.0.1"),
-        .package(url: "https://github.com/StanfordBDHG/ResearchKitOnFHIR.git", from: "2.0.1")
+        .package(url: "https://github.com/StanfordBDHG/ResearchKitOnFHIR.git", from: "2.0.4")
     ] + swiftLintPackage(),
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -30,11 +30,11 @@ let package = Package(
         .library(name: "SpeziTimedWalkTest", targets: ["SpeziTimedWalkTest"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.0.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.0.0"),
-        .package(url: "https://github.com/apple/FHIRModels", .upToNextMinor(from: "0.5.0")),
-        .package(url: "https://github.com/StanfordBDHG/ResearchKit", from: "3.0.1"),
-        .package(url: "https://github.com/StanfordBDHG/ResearchKitOnFHIR", from: "2.0.1")
+        .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.0.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/FHIRModels.git", from: "0.5.0"),
+        .package(url: "https://github.com/StanfordBDHG/ResearchKit.git", from: "3.0.1"),
+        .package(url: "https://github.com/StanfordBDHG/ResearchKitOnFHIR.git", from: "2.0.1")
     ] + swiftLintPackage(),
     targets: [
         .target(


### PR DESCRIPTION
# relax FHIRModels version requirement

## :recycle: Current situation & Problem
relaxes the FHIRModels version requirement from upToNextMinor to upToNextMajor; replaces all with the more elegant from: overload.

## :gear: Release Notes
n/a

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
